### PR TITLE
Clojure 1.4 compatibility fix

### DIFF
--- a/src/garden/units.clj
+++ b/src/garden/units.clj
@@ -224,7 +224,7 @@
 (defunit px)
 (defunit pt)
 (defunit pc)
-(defunit percent :%)
+(defunit percent (keyword "%"))
 
 ;; Angles
 


### PR DESCRIPTION
I've been trying to use garden on a project that absolutely cannot yet be upgraded to 1.5, but get a compilation error when requiring garden.units.

Without this small fix, projects running on previous versions of Clojure that have
not yet upgraded cannot require the units.clj namespace.
