### PR TITLE
upgrade Cljs to 0.2755 and remove redundant repls/brepls

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,12 +17,11 @@
   :profiles
   {:dev {:dependencies
          [[criterium "0.4.1"]
-          [org.clojure/clojurescript "0.0-2342"]
+          [org.clojure/clojurescript "0.0-2755"]
           [com.cemerick/piggieback "0.1.2"]]
 
          :plugins
-         [[com.cemerick/austin "0.1.3"]
-          [codox "0.6.4"]
+         [[codox "0.6.4"]
           [lein-cljsbuild "1.0.3"]
           [com.keminglabs/cljx "0.4.0"]
           [com.cemerick/clojurescript.test "0.3.1"]]


### PR DESCRIPTION
Staring with 0.2665 Cljs comes bundled with a much faster node repl and a brepl. Austin and piggieback are no longer required. The build times are faster too. On my machine, running `lein test-all` took around 16s. The updated version takes 9s, and this can improve with the new cljs compiler caching over time.

Fore more info, checkout the updated [mies](https://github.com/swannodette/mies/blob/master/src/leiningen/new/mies/README.md) lein template with pointers to David Nolen's blog.
