### PR TITLE
[WIP] support for vendor-prefixed values

### DIFF
--- a/src/cljx/garden/compiler.cljx
+++ b/src/cljx/garden/compiler.cljx
@@ -409,25 +409,39 @@
 
 (defn- prefixed-values
   "Sequence of values prefixed by each vendor in `vendors`."
+  [vendors vals val]
+  (set/union vals (map #(util/vendor-prefix % val) vendors)))
+
+(defn- prefix-all-values
+  "Prefix a sequence of values if `{:prefix true}` is in it's meta."
+  [vendors val]
+      (reduce #(prefixed-values vendors %1 %2) val val))
+
+(defn- prefix-auto-values
+  "Add prefixes to all values when it is in the `:auto-prefix` set."
+  [vendors val]
+  ; TODO: Implement
+  val)
+
+(defn- prefix-value
+  "Prefix a sequence of values if `{:prefix true}` is
+   set in its meta, or if a value is in the `:auto-prefix` set."
   [val]
-  (if-not (:prefix (meta val))
-    val
-    (let [vendors (or (:vendors (meta val)) (vendors))]
-      (reduce
-        (fn [val v]
-          (set/union val (map #(util/vendor-prefix % v) vendors)))
-        val
-        val))))
+  (let [vendors (or (:vendors (meta val)) (vendors))
+        prefix-fn (if (:prefix (meta val))
+                    prefix-all-values
+                    prefix-auto-values)]
+    (prefix-fn vendors val)))
 
 (defn- render-property-and-value
   [[prop val]]
   (if (set? val)
-    (->> (interleave (repeat prop) (prefixed-values val))
+    (->> (interleave (repeat prop) (prefix-value val))
          (partition 2)
          (map render-property-and-value)
          (string/join "\n"))
     (let [val (if (sequential? val)
-                (comma-separated-list render-value (prefixed-values val))
+                (comma-separated-list render-value (prefix-value val))
                 (render-value val))]
       (util/as-str prop colon val semicolon))))
 

--- a/src/cljx/garden/compiler.cljx
+++ b/src/cljx/garden/compiler.cljx
@@ -413,7 +413,11 @@
   (if-not (:prefix (meta val))
     val
     (let [vendors (or (:vendors (meta val)) (vendors))]
-      (reduce (fn [val v] (set/union val (map #(util/vendor-prefix % v) vendors))) val val))))
+      (reduce
+        (fn [val v]
+          (set/union val (map #(util/vendor-prefix % v) vendors)))
+        val
+        val))))
 
 (defn- render-property-and-value
   [[prop val]]

--- a/src/cljx/garden/compiler.cljx
+++ b/src/cljx/garden/compiler.cljx
@@ -415,7 +415,7 @@
 (defn- prefix-all-values
   "Prefix a sequence of values if `{:prefix true}` is in it's meta."
   [vendors val]
-      (reduce #(prefixed-values vendors %1 %2) val val))
+  (reduce #(prefixed-values vendors %1 %2) val val))
 
 (defn- prefix-auto-values
   "Add prefixes to all values when it is in the `:auto-prefix` set."

--- a/test/garden/compiler_test.cljx
+++ b/test/garden/compiler_test.cljx
@@ -180,6 +180,15 @@
 
     (let [compiled (compile-css
                     {:vendors test-vendors :pretty-print? false}
+                    [:ul {:display ^:prefix #{"flex"}}])]
+
+      (are [re] (re-find re compiled)
+        #"display:-moz-flex"
+        #"display:-webkit-flex"
+        #"display:flex"))
+
+    (let [compiled (compile-css
+                    {:vendors test-vendors :pretty-print? false}
                     (at-keyframes "fade"
                       [:from {:foo "bar"}]
                       [:to {:foo "baz"}]))]

--- a/test/garden/compiler_test.cljx
+++ b/test/garden/compiler_test.cljx
@@ -180,12 +180,15 @@
 
     (let [compiled (compile-css
                     {:vendors test-vendors :pretty-print? false}
-                    [:ul {:display ^:prefix #{"flex"}}])]
+                    [:ul {:display ^:prefix #{"flex" "inline-flex"}}])]
 
       (are [re] (re-find re compiled)
         #"display:-moz-flex"
         #"display:-webkit-flex"
-        #"display:flex"))
+        #"display:flex"
+        #"display:-moz-inline-flex"
+        #"display:-webkit-inline-flex"
+        #"display:inline-flex"))
 
     (let [compiled (compile-css
                     {:vendors test-vendors :pretty-print? false}


### PR DESCRIPTION
This adds support for vendor-prefixed values like `display: flex`, since you can't add metadata to string you have to wrap your value in a set.
I still have to add support for auto-prefixing.

```clojure
user => (css
         {:vendors ["webkit"]
         [:.foo {:display ^:prefix #{"flex"}}])
".foo{display:flex;display:-webkit-flex;}"
```