### PR TITLE
Fix typo and suggestion

### DIFF
--- a/src/garden/def.clj
+++ b/src/garden/def.clj
@@ -11,9 +11,9 @@
   `(def ~name (list ~@styles)))
 
 (defmacro defstylesfn
-  "Convenience macro equivalent to `(defn name [] (list styles*))`."
-  [name & styles]
-  `(defn ~name [] (list ~@styles)))
+  "Convenience macro equivalent to `(defn name binding] (list styles*))`."
+  [name binding & styles]
+  `(defn ~name ~binding (list ~@styles)))
 
 (defmacro defstylesheet
   "Convenience macro equivalent to `(def name (css opts? styles*))`."
@@ -21,9 +21,9 @@
   `(def ~name (garden.core/css ~@styles)))
 
 (defmacro defstylesheetfn
-  "Convenience macro equivalent to `(defn name [opts?] (css opts? styles*))`."
-  [name & styles]
-  `(defn ~name [& [opts#]] (garden.core/css opts# ~@styles)))
+  "Convenience macro equivalent to `(defn name [opts? & binding] (css opts? styles*))`."
+  [name binding & styles]
+  `(defn ~name [opts# ~@binding] (garden.core/css opts# ~@styles)))
 
 (defmacro defrule
   "Define a function for creating rules. If only the `name` argument is

--- a/src/garden/def.clj
+++ b/src/garden/def.clj
@@ -10,10 +10,20 @@
   [name & styles]
   `(def ~name (list ~@styles)))
 
+(defmacro defstylesfn
+  "Convenience macro equivalent to `(defn name [] (list styles*))`."
+  [name & styles]
+  `(defn ~name [] (list ~@styles)))
+
 (defmacro defstylesheet
   "Convenience macro equivalent to `(def name (css opts? styles*))`."
   [name & styles]
   `(def ~name (garden.core/css ~@styles)))
+
+(defmacro defstylesheetfn
+  "Convenience macro equivalent to `(defn name [opts?] (css opts? styles*))`."
+  [name & styles]
+  `(defn ~name [& [opts#]] (garden.core/css opts# ~@styles)))
 
 (defmacro defrule
   "Define a function for creating rules. If only the `name` argument is

--- a/src/garden/def.clj
+++ b/src/garden/def.clj
@@ -53,7 +53,7 @@
   accept any number of arguments.
 
   Ex.
-      (def cssfn url)
+      (defcssfn url)
       ;; => #'user/url
 
       (url \"http://fonts.googleapis.com/css?family=Lato\")


### PR DESCRIPTION
First, thank for the garden hard work :+1: 

I suggest new `defnstyle` and `defnstylesheet` macros for live coding. `def` feels like static declaration.

```clojure
(def ^:dynamic color-palette
  {:background "#000000"
   :foreground "#ececec"})

(defnstyles base
  ((rule :html :body)
   {:margin "0" :padding "0"
    :height "100%"
    :font [["400" "16px/18px"] 'Roboto 'sans-serif]
    :color (color-palette :foreground)
    :background-color (color-palette :background)})

(defnstylesheet root-css
  (base))

(root-css {:pretty-print? false})

(binding [color-palette (assoc color-palette :background (rgb 20 20 20))]
    (root-css {:pretty-print? false}))
```