### PR TITLE
Fix Clojure 1.7/self-hosting cljs/figwheel issues

### DIFF
--- a/src/garden/selectors.cljc
+++ b/src/garden/selectors.cljc
@@ -823,7 +823,7 @@
     last-child
     last-of-type
     left
-    link
+    links
     only-child
     only-of-type
     optional

--- a/src/garden/selectors.cljc
+++ b/src/garden/selectors.cljc
@@ -10,7 +10,7 @@
               clojure.lang.IFn
               clojure.lang.Named))
   #?(:cljs
-     (:refer-clojure :exclude [+ - > empty first map meta not]))
+     (:refer-clojure :exclude [+ - > empty first map meta not time]))
   #?(:cljs
      (:require-macros
       [garden.selectors :refer [defselector

--- a/src/garden/units.cljc
+++ b/src/garden/units.cljc
@@ -1,7 +1,6 @@
 (ns garden.units
   "Functions and macros for working with CSS units."
-  #?(:clj
-     (:refer-clojure :exclude [rem]))
+  (:refer-clojure :exclude [rem])
   #?(:cljs
      (:require-macros
       [garden.units :refer [defunit]]))


### PR DESCRIPTION
Two tiny commits (the second one shouldn't be merged in as-is):

 1. Fix the way refer is used to avoid warnings of over-riding built-in cljs functions
 1. `link` was being defined twice by the macros - I'm unclear on the differences (hence this shouldn't be merged in as-is) so I just renamed the secondary one from `link` -> `links`.

Needed to get it to this point so that figwheel worked (while still warning be about my code that had these warnings)