### PR TITLE
fixed bug where hsl value in rgb->hsl can be > 100

### DIFF
--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -153,7 +153,9 @@
              (= mx mn) 0
              (< l 0.5) (/ d (* 2 l))
              :else (/ d (- 2 (* 2 l))))]
-      (hsl (mod h 360) (* 100 s) (* 100 l)))))
+      (hsl (percent-clip (mod h 360))
+           (percent-clip (* 100 s))
+           (percent-clip (* 100 l))))))
 
 (declare hue->rgb)
 

--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -43,6 +43,12 @@
 
 (def as-color map->CSSColor)
 
+(def percent-clip
+  (partial util/clip 0 100))
+
+(def rgb-clip
+  (partial util/clip 0 255))
+
 (defn rgb
   "Create an RGB color."
   ([[r g b :as vs]]
@@ -199,12 +205,6 @@
   "Convert a hexadecimal color to an HSL color."
   [color]
   (-> color hex->rgb rgb->hsl))
-
-(def percent-clip
-  (partial util/clip 0 100))
-
-(def rgb-clip
-  (partial util/clip 0 255))
 
 (defn as-hex
   "Convert a color to a hexadecimal string."


### PR DESCRIPTION
I found a bug when calling rgb->hsl with {:red 255 :green 133 :blue 27}
the function calculates the hsl values to:
27.89473684210526 100.00000000000003 55.294117647058826
and then the function hsl throws this error:
Error: Saturation and lightness must be between 0(%) and 100(%)

--> so i fixed it with calling clip-percent for each value
