### PR TITLE
fixed bug when rgb->hsl value can be > 100

### DIFF
--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -133,7 +133,10 @@
             (-> (util/format "%2s" (util/int->string v 16))
                 (string/replace " " "0")))]
     (apply str "#" (map hex-part [r g b]))))
-    
+
+(defn trim-one [x]
+  (if (< 1 x) 1 x))
+
 (defn rgb->hsl
   "Convert an RGB color map to an HSL color map."
   [{:keys [red green blue] :as color}]
@@ -148,11 +151,11 @@
               r (* 60 (/ (- g b) d))
               g (+ (* 60 (/ (- b r) d)) 120)
               b (+ (* 60 (/ (- r g) d)) 240))
-          l (/ (+ mx mn) 2)
-          s (cond
+          l (trim-one (/ (+ mx mn) 2))
+          s (trim-one (cond
              (= mx mn) 0
              (< l 0.5) (/ d (* 2 l))
-             :else (/ d (- 2 (* 2 l))))]
+             :else (/ d (- 2 (* 2 l)))))]
       (hsl (mod h 360) (* 100 s) (* 100 l)))))
 
 (declare hue->rgb)

--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -151,11 +151,12 @@
               r (* 60 (/ (- g b) d))
               g (+ (* 60 (/ (- b r) d)) 120)
               b (+ (* 60 (/ (- r g) d)) 240))
-          l (trim-one (/ (+ mx mn) 2))
-          s (trim-one (cond
-             (= mx mn) 0
-             (< l 0.5) (/ d (* 2 l))
-             :else (/ d (- 2 (* 2 l)))))]
+          l (/ (+ mx mn) 2)
+          s (trim-one
+              (cond
+                (= mx mn) 0
+                (< l 0.5) (/ d (* 2 l))
+                :else (/ d (- 2 (* 2 l)))))]
       (hsl (mod h 360) (* 100 s) (* 100 l)))))
 
 (declare hue->rgb)

--- a/test/garden/color_test.cljc
+++ b/test/garden/color_test.cljc
@@ -18,14 +18,16 @@
 (def rgb-green (color/rgb 0 255 0))
 (def rgb-blue (color/rgb 0 0 255))
 (def rgb-white (color/rgb 255 255 255))
+(def rgb-orange (color/rgb 255 133 27))
 
 (def hsl-black (color/hsl 0 0 0))
 (def hsl-red (color/hsl 0 100 50))
 (def hsl-green (color/hsl 120 100 50))
 (def hsl-blue (color/hsl 240 100 50))
 (def hsl-white (color/hsl 0 0 100))
+(def hsl-orange (color/hsl 530/19 100 940/17))
 
-(deftest color-conversion-test 
+(deftest color-conversion-test
   (testing "hex->rgb"
     (are [x y] (= x y)
       (color/hex->rgb hex-black) rgb-black
@@ -55,7 +57,8 @@
       (color/rgb->hsl rgb-red) hsl-red
       (color/rgb->hsl rgb-green) hsl-green
       (color/rgb->hsl rgb-blue) hsl-blue
-      (color/rgb->hsl rgb-white) hsl-white))) 
+      (color/rgb->hsl rgb-white) hsl-white
+      (color/rgb->hsl rgb-orange) hsl-orange)))
 
 (deftest color-math-test
   (testing "color+"


### PR DESCRIPTION
I found a bug when calling `rgb->hsl` with `{:red 255 :green 133 :blue 27}`
the function calculates the hsl values to:
```
27.89473684210526 100.00000000000003 55.294117647058826
```
and then the function `hsl` throws this error:
```
Error: Saturation and lightness must be between 0(%) and 100(%)
```
--> so i fixed it with triming the values > 1 to 1 before multiplying them by 100
