### PR TITLE
feat: add documentation for at-rules to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ user=> (css [:pre {:font-family "\"Liberation Mono\", Consolas, monospace"}])
 "pre{font-family:\"Liberation Mono\", Consolas, monospace}"
 ```
 
+##### At-rules
+
+Where CSS notation uses constructs such as @media, @keywords et al.,
+you can use the `at-rules` functions from `garden.stylesheet`.
+See `at-font-face`, `at-import`, `at-media` and `at-keyframes`.
+
 ## Further Reading & Wiki
 
 Detailed documentation and a developer guide for Syntax, Rules, Declarations,


### PR DESCRIPTION
How about documenting at least these common functions also on the front page? I could've used this myself a while ago.