### PR TITLE
Fix cljs compile errors

### DIFF
--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -595,12 +595,14 @@
   (-> hex
       (string/replace #"^#" "")
       (expand-hex)
-      (Long/parseLong 16)))
+      #?(:clj (Long/parseLong 16)
+         :cljs (js/parseInt 16))))
 
 (defn- long->hex
   "(long->hex 11189196) -> \"aabbcc\""
   [long]
-  (Integer/toHexString long))
+  #?(:clj (Integer/toHexString long)
+     :cljs (.toString long 16)))
 
 (defn weighted-mix
   "`weight` is number 0 to 100 (%).


### PR DESCRIPTION
This fixes some ClojureScript compile errors where garden is currently lacking reader conditionals.

As a sidenote, this seems to have gone by unseen because running `lein test-cljs` performs the tests on the JVM rather than a JS engine. Although warnings are printed before running the tests notifying of the compile failure, the tests appear to run flawlessly.