### PR TITLE
fix typo with space

### DIFF
--- a/src/garden/def.clj
+++ b/src/garden/def.clj
@@ -53,7 +53,7 @@
   accept any number of arguments.
 
   Ex.
-      (def cssfn url)
+      (defcssfn url)
       ;; => #'user/url
 
       (url \"http://fonts.googleapis.com/css?family=Lato\")


### PR DESCRIPTION
There's a typo in the def documentation for `defcssfn`, it threw me for a bit. 