### PR TITLE
Improve support for Map-like collections inside styles

### DIFF
--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -172,7 +172,7 @@
 
 (def
   ^{:private true
-    :doc "Matches a single \"&\" or \"&\" follow by one or more 
+    :doc "Matches a single \"&\" or \"&\" follow by one or more
   non-whitespace characters."}
   parent-selector-re
   #"^&(?:\S+)?$")
@@ -248,11 +248,11 @@
 
 (defmethod expand-at-rule :media
   [{:keys [value]}]
-  (let [{:keys [media-queries rules]} value 
+  (let [{:keys [media-queries rules]} value
         media-queries (expand-media-query-expression media-queries)
         xs (with-media-query-context media-queries             (doall (mapcat expand (expand rules))))
         ;; Though media-queries may be nested, they may not be nested
-        ;; at compile time. Here we make sure this is the case.  
+        ;; at compile time. Here we make sure this is the case.
         [subqueries rules] (divide-vec util/at-media? xs)]
     (cons
      (CSSAtRule. :media {:media-queries media-queries
@@ -503,7 +503,7 @@
 (defn- render-media-expr
   "Make a media query expession from one or more maps. Keys are not
   validated but values have the following semantics:
-  
+
     `true`  as in `{:screen true}`  == \"screen\"
     `false` as in `{:screen false}` == \"not screen\"
     `:only` as in `{:screen :only}  == \"only screen\""
@@ -556,7 +556,7 @@
 
 (defmethod render-at-rule :import
   [{:keys [value]}]
-  (let [{:keys [url media-queries]} value 
+  (let [{:keys [url media-queries]} value
         url (if (string? url)
               (util/wrap-quotes url)
               (render-css url))
@@ -596,7 +596,7 @@
            l-brace-1
            (-> (map render-css rules)
                (rule-join)
-               (indent-str)) 
+               (indent-str))
            r-brace-1))))
 
 
@@ -707,7 +707,7 @@
   [flags rules]
   (binding [*flags* flags]
     (->> (expand-stylesheet rules)
-         (filter top-level-expression?) 
+         (filter top-level-expression?)
          (map render-css)
          (remove nil?)
          (rule-join))))
@@ -725,7 +725,7 @@
   "Compress CSS if the pretty-print(?) flag is true."
   [{:keys [pretty-print? pretty-print]} stylesheet]
   ;; Also accept pretty-print like CLJS.
-  (if (or pretty-print? pretty-print) 
+  (if (or pretty-print? pretty-print)
     stylesheet
     (compression/compress-stylesheet stylesheet)))
 

--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -159,7 +159,7 @@
           m
           (expand-declaration-1 v))
          (assoc m (util/to-str k) v)))
-     {}
+     (empty d)
      d)))
 
 (defn- expand-declaration

--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -149,6 +149,7 @@
 
 (defn expand-declaration-1
   [declaration]
+  {:pre [(map? declaration)]}
   (let [prefix #(util/as-str %1 "-" %2)]
     (reduce
      (fn [m [k v]]

--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -148,7 +148,7 @@
 ;; Declaration expansion
 
 (defn expand-declaration-1
-  [d]
+  [declaration]
   (let [prefix #(util/as-str %1 "-" %2)]
     (reduce
      (fn [m [k v]]
@@ -159,13 +159,13 @@
           m
           (expand-declaration-1 v))
          (assoc m (util/to-str k) v)))
-     (empty d)
-     d)))
+     (empty declaration)
+     declaration)))
 
 (defn- expand-declaration
-  [d]
-  (when (seq d)
-    (with-meta (expand-declaration-1 d) (meta d))))
+  [declaration]
+  (when (seq declaration)
+    (with-meta (expand-declaration-1 declaration) (meta declaration))))
 
 ;; ---------------------------------------------------------------------
 ;; Rule expansion

--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -164,7 +164,8 @@
 
 (defn- expand-declaration
   [declaration]
-  (when (seq declaration)
+  (if (empty? declaration)
+    declaration
     (with-meta (expand-declaration-1 declaration) (meta declaration))))
 
 ;; ---------------------------------------------------------------------

--- a/test/garden/compiler_test.cljc
+++ b/test/garden/compiler_test.cljc
@@ -40,8 +40,20 @@
     (is (render= {:a [1 2 3]}
                  "a: 1, 2, 3;"))
     (is (render= {:a [[1 2] 3 [4 5]]}
-                 "a: 1 2, 3, 4 5;")))
-  
+                 "a: 1 2, 3, 4 5;"))
+
+    (testing "ordering"
+      (is (render= {:a 1 :b 2 :c 3 :d 4 :e 5 :f 6 :g 7 :h 8}
+                   "a: 1;\nb: 2;\nc: 3;\nd: 4;\ne: 5;\nf: 6;\ng: 7;\nh: 8;"))
+      (is (not (render= {:a 1 :b 2 :c 3 :d 4 :e 5 :f 6 :g 7 :h 8 :i 9}
+                        "a: 1;\nb: 2;\nc: 3;\nd: 4;\ne: 5;\nf: 6;\ng: 7;\nh: 8;\ni: 9;")))
+      (is (not (render= (array-map :a 1 :b 2 :c 3 :d 4 :e 5 :f 6 :g 7 :h 8 :i 9 :j 10)
+                        "a: 1;\nb: 2;\nc: 3;\nd: 4;\ne: 5;\nf: 6;\ng: 7;\nh: 8;\ni: 9;\nj: 10;")))
+      (is (render= (sorted-map :a 1 :k 11 :b 2 :j 10 :c 3 :i 9 :d 4 :h 8 :e 5 :g 7 :f 6)
+                   "a: 1;\nb: 2;\nc: 3;\nd: 4;\ne: 5;\nf: 6;\ng: 7;\nh: 8;\ni: 9;\nj: 10;\nk: 11;"))
+      (is (render= (sorted-map-by #(compare %2 %1) :a 1 :b 2 :c 3 :d 4 :e 5 :f 6 :g 7 :h 8 :i 9 :j 10 :k 11)
+                   "k: 11;\nj: 10;\ni: 9;\nh: 8;\ng: 7;\nf: 6;\ne: 5;\nd: 4;\nc: 3;\nb: 2;\na: 1;" ))))
+
   (testing "vectors"
     (is (compile= [:a {:x 1} {:y 2}]
                   "a{x:1;y:2}"))

--- a/test/garden/compiler_test.cljc
+++ b/test/garden/compiler_test.cljc
@@ -25,7 +25,7 @@
 (def test-vendors ["moz" "webkit"])
 
 ;; Tests
-(deftest render-css-test 
+(deftest render-css-test
   (testing "maps"
     (is (render= {:a 1}
                  "a: 1;"))
@@ -141,19 +141,19 @@
     (is (render= (CSSFunction. :x [(CSSFunction. :y 1) (CSSFunction. :z 2)])
                  "x(y(1), z(2))"))))
 
-(deftest at-rule-test 
+(deftest at-rule-test
   (testing "@import"
     (let [url "http://example.com/foo.css"]
       (is (render= (at-import url)
                    "@import \"http://example.com/foo.css\";"))
-      (is (render= (at-import url {:screen true}) 
+      (is (render= (at-import url {:screen true})
                    "@import \"http://example.com/foo.css\" screen;"))))
 
   (testing "@keyframes"
     (let [kfs (at-keyframes :id
                             [:from {:x 0}]
                             [:to {:x 1}])]
-      (is (compile= kfs 
+      (is (compile= kfs
                     "@keyframes id{from{x:0}to{x:1}}"))
       (is (compile= [:a {:d kfs}]
                     "a{d:id}")))))


### PR DESCRIPTION
By changing `{}` with `(empty d)` inside the `expand-declaration-1` call, we gain 
the ability to use different Map-like collections in the style definition. Without it, 
every collection is casted to a map during the processing. This can become an 
issue when (e.g) we need the output in a specific order, since clojure maps are 
not ordered by definition.

The new tests verify that the underlying collection properties are preserved
during processing, such as the sorting comparator. Although not in the tests, 
metadata is also preserved.

The tests also take into account that a regular `map` will take up to 8 elements 
before losing ordering. (Internally, the array-map becomes a hash-map). 
Explicit `array-map`s receive up to 9 elements before losing ordering.

I've also tested it locally with `org.flatland/ordered` collections. It's not on the 
tests due to the added dependency, but can be added if its important.