### PR TITLE
Debug Scaling Operations

### DIFF
--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -555,11 +555,13 @@
     h
     (throw (ex-info-color-name n))))
 
+(defn- clamp
+  [value min-val max-val]
+  (max min-val (min value max-val)))
+
 (defn- scale-color-value
-  [value amount]
-  (+ value (if (pos? amount)
-             (* (- 100 value) (/ amount 100))
-             (/ (* value amount) 100))))
+  [value amt]
+  (clamp (* value (+ 1 (/ amt 100))) 0 100))
 
 (defn scale-lightness
   "Scales the lightness of a color by amount, which is treated as a percentage.

--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -555,13 +555,12 @@
     h
     (throw (ex-info-color-name n))))
 
-(defn- clamp
-  [value min-val max-val]
-  (max min-val (min value max-val)))
-
 (defn- scale-color-value
-  [value amt]
-  (clamp (* value (+ 1 (/ amt 100))) 0 100))
+  ([value amount]
+    (scale-color-value value amount 0 100))
+  ([value amount min-val max-val]
+    (util/clip min-val max-val (* value (+ 1 (/ amount 100))))))
+
 
 (defn scale-lightness
   "Scales the lightness of a color by amount, which is treated as a percentage.

--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -14,9 +14,9 @@
 ;; the implementations included with Sass
 ;; (http://sass-lang.com/docs/yardoc/Sass/Script/Functions.html).
 ;; Some additional functions have been added such as `triad` and
-;; `tetrad` for generating sets of colors. 
+;; `tetrad` for generating sets of colors.
 
-;; Converts a color to a hexadecimal string (implementation below). 
+;; Converts a color to a hexadecimal string (implementation below).
 (declare as-hex)
 
 (defrecord CSSColor [red green blue hue saturation lightness alpha]
@@ -66,7 +66,7 @@
 (defn hsl
   "Create an HSL color."
   ([[h s l]]
-     ;; Handle CSSUnits. 
+     ;; Handle CSSUnits.
      (let [[h s l] (map #(get % :magnitude %) [h s l])]
        (if (and (util/between? s 0 100)
                 (util/between? l 0 100))
@@ -320,7 +320,7 @@
   ([color-1 color-2 & more]
      (reduce mix (mix color-1 color-2) more)))
 
-;;;; Color wheel functions. 
+;;;; Color wheel functions.
 
 (defn complement
   "Return the complement of a color."

--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -562,12 +562,14 @@
              (/ (* value amount) 100))))
 
 (defn scale-lightness
-  "Scale the lightness of a color by amount"
+  "Scales the lightness of a color by amount, which is treated as a percentage.
+  Supply positive values to scale upwards and negative values to scale downwards."
   [color amount]
   (update-color color :lightness scale-color-value amount))
 
 (defn scale-saturation
-  "Scale the saturation of a color by amount"
+  "Scales the saturation of a color by amount, which is treated as a percentage.
+  Supply positive values to scale upwards and negative values to scale downwards."
   [color amount]
   (update-color color :saturation scale-color-value amount))
 

--- a/test/garden/color_test.cljc
+++ b/test/garden/color_test.cljc
@@ -214,13 +214,21 @@
 
 (deftest scale-lightness-test []
   (testing "scale-lightness"
-    (is (= 75 (-> (color/hsl 50 50 50) (color/scale-lightness 50) :lightness)))
-    (is (= 25 (-> (color/hsl 50 50 50) (color/scale-lightness -50) :lightness)))))
+    (is (= 75 (-> (color/hsl 50 50 50) (color/scale-lightness   50) :lightness)))
+    (is (= 25 (-> (color/hsl 50 50 50) (color/scale-lightness  -50) :lightness)))
+    (is (= 20 (-> (color/hsl 50 50 10) (color/scale-lightness  100) :lightness)))
+    (is (=  0 (-> (color/hsl 50 50 10) (color/scale-lightness -100) :lightness)))
+    (is (= 15 (-> (color/hsl 50 50 10) (color/scale-lightness   50) :lightness)))
+    (is (=  5 (-> (color/hsl 50 50 10) (color/scale-lightness  -50) :lightness)))))
 
 (deftest scale-saturation-test []
   (testing "scale-lightness"
-    (is (= 75 (-> (color/hsl 50 50 50) (color/scale-saturation 50) :saturation)))
-    (is (= 25 (-> (color/hsl 50 50 50) (color/scale-saturation -50) :saturation)))))
+    (is (= 75 (-> (color/hsl 50 50 50) (color/scale-saturation   50) :saturation)))
+    (is (= 25 (-> (color/hsl 50 50 50) (color/scale-saturation  -50) :saturation)))
+    (is (= 20 (-> (color/hsl 50 10 50) (color/scale-saturation  100) :saturation)))
+    (is (=  0 (-> (color/hsl 50 10 50) (color/scale-saturation -100) :saturation)))
+    (is (= 15 (-> (color/hsl 50 10 50) (color/scale-saturation   50) :saturation)))
+    (is (=  5 (-> (color/hsl 50 10 50) (color/scale-saturation  -50) :saturation)))))
 
 (deftest hex-tests []
   (testing "decrown hex"


### PR DESCRIPTION
Calls to color/scale-lightness were returning unexpected values.


```clojure
(color/scale-lightness (hsl 50 50 10) 100)
;; returned a lightness of 100 instead of 20
```

```clojure
(color/scale-lightness (hsl 50 50 20) 10) 
;; returned a lightness of 28 instead of 22
```

This PR debugs the scaling impls, updates documentation, and bolsters test 
coverage.

See commits for more details.