### PR TITLE
Rename CSSFunction function property to f

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+**Breaking Change:** The `function` field in `CSSFunction` has been renamed to avoid Closure Compiler warnings. [#144](https://github.com/noprompt/garden/issues/144) 
+
 ## Changes from 1.3.0
 
 Migrate cljx to cljc and maintain parity with Clojure/Cljs with 1.7. For

--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -532,11 +532,11 @@
 (defn- render-function
   "Render a CSS function."
   [css-function]
-  (let [{:keys [function args]} css-function
+  (let [{:keys [f args]} css-function
         args (if (sequential? args)
                (comma-separated-list args)
                (util/to-str args))]
-    (util/format "%s(%s)" (util/to-str function) args)))
+    (util/format "%s(%s)" (util/to-str f) args)))
 
 (defn ^:private render-color [c]
   (if-let [a (:alpha c)]

--- a/src/garden/types.cljc
+++ b/src/garden/types.cljc
@@ -3,6 +3,6 @@
 
 (defrecord CSSUnit [unit magnitude])
 
-(defrecord CSSFunction [function args])
+(defrecord CSSFunction [f args])
 
 (defrecord CSSAtRule [identifier value])


### PR DESCRIPTION
Newer version of the Closure compiler warn about naming a property `function`. The CSSFunction defrecord has a field called `function`. This commit renames it to `f` to avoid these compiler warnings.

As far as I can tell, the `function` field was only used in a single place throughout the whole codebase.

This is a breaking change if anyone was relying on that field.

Fixes #144