### PR TITLE
Add support for feature queries with @supports to garden

### DIFF
--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -505,7 +505,7 @@
 ;; Media query rendering
 
 (defn- render-media-expr-part
-  "Render the individual components of a query expression."
+  "Render the individual components of a media expression."
   [[k v]]
   (let [[sk sv] (map render-value [k v])]
     (cond
@@ -517,7 +517,7 @@
               (str "(" sk ")")))))
 
 (defn- render-media-expr
-  "Make a query expession from one or more maps. Keys are not
+  "Make a media query expession from one or more maps. Keys are not
   validated but values have the following semantics:
 
     `true`  as in `{:screen true}`  == \"screen\"
@@ -543,12 +543,8 @@
       (str "(" sk ")"))))
 
 (defn- render-feature-expr
-  "Make a query expession from one or more maps. Keys are not
-  validated but values have the following semantics:
-
-    `true`  as in `{:screen true}`  == \"screen\"
-    `false` as in `{:screen false}` == \"not screen\"
-    `:only` as in `{:screen :only}  == \"only screen\""
+  "Make a query expression from one or more maps. Keys are not
+  validated."
   [expr]
   (if (sequential? expr)
     (->> (map render-feature-expr expr)

--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -242,7 +242,7 @@
 
 ;; @media expansion
 
-(defn- expand-query-expression [expression]
+(defn- expand-media-query-expression [expression]
   (if-let [f (->> [:media-expressions :nesting-behavior]
                   (get-in *flags*)
                   (media-expression-behavior))]
@@ -252,8 +252,8 @@
 (defmethod expand-at-rule :media
   [{:keys [value]}]
   (let [{:keys [media-queries rules]} value
-        media-queries (expand-query-expression media-queries)
-        xs (with-media-query-context media-queries (doall (mapcat expand (expand rules))))
+        media-queries (expand-media-query-expression media-queries)
+        xs (with-media-query-context media-queries             (doall (mapcat expand (expand rules))))
         ;; Though media-queries may be nested, they may not be nested
         ;; at compile time. Here we make sure this is the case.
         [subqueries rules] (divide-vec util/at-media? xs)]
@@ -265,7 +265,7 @@
 (defmethod expand-at-rule :feature
   [{:keys [value]}]
   (let [{:keys [feature-queries rules]} value
-        feature-queries (expand-query-expression feature-queries)
+        feature-queries (expand-media-query-expression feature-queries)
         xs (with-media-query-context feature-queries (doall (mapcat expand (expand rules))))
         ;; Though feature-queries may be nested, they may not be nested
         ;; at compile time. Here we make sure this is the case.

--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -30,17 +30,17 @@
    ;; `{:ouput-style => :expanded}` in Sass. When set to `false`
    ;; the compiled stylesheet will be compressed with the YUI
    ;; compressor.
-   :pretty-print?     true
+   :pretty-print? true
    ;; A sequence of files to prepend to the output file.
-   :preamble          []
+   :preamble []
    ;; Location to save a stylesheet after compiling.
-   :output-to         nil
+   :output-to nil
    ;; A list of vendor prefixes to prepend to things like
    ;; `@keyframes`, properties within declarations containing the
    ;; `^:prefix` meta data, and properties defined in `:auto-prefix`.
-   :vendors           []
+   :vendors []
    ;; A set of properties to automatically prefix with `:vendors`.
-   :auto-prefix       #{}
+   :auto-prefix #{}
    ;; `@media` and '@supports' query configuration.
    :media-expressions {;; May either be `:merge` or `:default`. When
                        ;; set to `:merge` nested query expressions will
@@ -50,11 +50,11 @@
 
 (def
   ^{:private true
-    :doc "Retun a function to call when rendering a query expression.
-  The returned function accepts two arguments: the query
-  expression being evaluated and the current query expression context.
+    :doc "Retun a function to call when rendering a media expression.
+  The returned function accepts two arguments: the media
+  expression being evaluated and the current media expression context.
   Both arguments are maps. This is used to provide semantics for nested
-  query expressions."}
+  media expressions.  Also used to support feature queries"}
   media-expression-behavior
   {:merge (fn [expr context] (merge context expr))
    :default (fn [expr _] expr)})

--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -54,7 +54,7 @@
   The returned function accepts two arguments: the media
   expression being evaluated and the current media expression context.
   Both arguments are maps. This is used to provide semantics for nested
-  media expressions.  Also used to support feature queries"}
+  media queries.  Also used to support feature queries"}
   media-expression-behavior
   {:merge (fn [expr context] (merge context expr))
    :default (fn [expr _] expr)})

--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -41,7 +41,7 @@
    :vendors []
    ;; A set of properties to automatically prefix with `:vendors`.
    :auto-prefix #{}
-   ;; `@media` and '@supports' query configuration.
+   ;; `@media` and `@supports` query configuration.
    :media-expressions {;; May either be `:merge` or `:default`. When
                        ;; set to `:merge` nested query expressions will
                        ;; have their expressions merged with their
@@ -54,7 +54,7 @@
   The returned function accepts two arguments: the media
   expression being evaluated and the current media expression context.
   Both arguments are maps. This is used to provide semantics for nested
-  media queries.  Also used to support feature queries"}
+  media queries.  Also used to support feature queries."}
   media-expression-behavior
   {:merge (fn [expr context] (merge context expr))
    :default (fn [expr _] expr)})

--- a/src/garden/stylesheet.cljc
+++ b/src/garden/stylesheet.cljc
@@ -61,6 +61,7 @@
                    :rules rules}))
 
 (defn at-supports [feature-queries & rules]
+  "Create a CSS @supports rule."
   (at-rule :feature {:feature-queries feature-queries
                      :rules rules}))
 

--- a/src/garden/stylesheet.cljc
+++ b/src/garden/stylesheet.cljc
@@ -60,6 +60,10 @@
   (at-rule :media {:media-queries media-queries
                    :rules rules}))
 
+(defn at-supports [feature-queries & rules]
+  (at-rule :feature {:feature-queries feature-queries
+                     :rules rules}))
+
 (defn at-keyframes
   "Create a CSS @keyframes rule."
   [identifier & frames]

--- a/src/garden/util.cljc
+++ b/src/garden/util.cljc
@@ -106,6 +106,11 @@
   [x]
   (and (at-rule? x) (= (:identifier x) :media)))
 
+(defn at-supports?
+  "True if `x` is a CSS `@supports` rule."
+  [x]
+  (and (at-rule? x) (= (:identifier x) :feature)))
+
 (defn at-keyframes?
   "True if `x` is a CSS `@keyframes` rule."
   [x]

--- a/test/garden/compiler_test.cljc
+++ b/test/garden/compiler_test.cljc
@@ -251,7 +251,7 @@
   (testing ":media-expressions :nesting-behavior"
     (let [compiled (compile-css
                     {:media-expressions {:nesting-behavior :merge}
-                     :pretty-print?     false}
+                     :pretty-print? false}
                     (at-media {:screen true}
                               [:a {:x 1}]
                               (at-media {:print true}

--- a/test/garden/compiler_test.cljc
+++ b/test/garden/compiler_test.cljc
@@ -250,7 +250,7 @@
 
   (testing ":query-expressions :nesting-behavior"
     (let [compiled (compile-css
-                     {:query-expressions {:nesting-behavior :merge}
+                     {:media-expressions {:nesting-behavior :merge}
                       :pretty-print?     false}
                      (at-media {:screen true}
                               [:a {:x 1}]

--- a/test/garden/compiler_test.cljc
+++ b/test/garden/compiler_test.cljc
@@ -248,11 +248,11 @@
       (is (not (re-find #"-moz-c:1" compiled)))
       (is (not (re-find #"-webkit-c:1" compiled)))))
 
-  (testing ":query-expressions :nesting-behavior"
+  (testing ":media-expressions :nesting-behavior"
     (let [compiled (compile-css
-                     {:media-expressions {:nesting-behavior :merge}
-                      :pretty-print?     false}
-                     (at-media {:screen true}
+                    {:media-expressions {:nesting-behavior :merge}
+                     :pretty-print?     false}
+                    (at-media {:screen true}
                               [:a {:x 1}]
                               (at-media {:print true}
                                         [:b {:y 1}])))]


### PR DESCRIPTION
Hey Joel!  This is the change I spoke to you about earlier.

I decided to make it completely separate (i.e. not refactor to make generics) so that it would be completely compatible with whatever other patches people have made in their own forks.

All the tests are passing, and I've been using it for a while not, all looks good.  I know you're eyeing 2.0.0, but this might at least assist in the meantime :D