### PR TITLE
Fix documentation string of color-div

### DIFF
--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -293,7 +293,7 @@
   color* *)
 
 (defcolor-operation
-  ^{:doc "Multiply the RGB components of two or more colors."
+  ^{:doc "Divide the RGB components of two or more colors."
     :arglists '([a] [a b] [a b & more])}
   color-div /)
 


### PR DESCRIPTION
Here is a fix for a small typo I saw while looking over the documentation.