### PR TITLE
[project] Clean compile warnings.

### DIFF
--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -180,7 +180,7 @@
                (* l (inc s))
                (- (+ l s) (* l s)))
           m1 (- (* 2 l) m2)
-          [r g b] (map #(Math/round (* % 0xff))
+          [r g b] (map #(int (+ 0.5 (* % 0xff)))
                        [(hue->rgb m1 m2 (+ h (/ 1.0 3)))
                         (hue->rgb m1 m2 h)
                         (hue->rgb m1 m2 (- h (/ 1.0 3)))])]
@@ -387,6 +387,10 @@
      (let [d (util/clip 1 179 distance-from-complement)]
          (hue-rotations color 0 d (- d)))))
 
+(defn- abs
+  [x]
+  (if (neg? x) (- x) x))
+
 (defn tetrad
   "Given a color return a quadruple of four colors which are
   equidistance on the color wheel (ie. a pair of complements). An
@@ -395,7 +399,7 @@
   ([color]
      (tetrad color 90))
   ([color angle]
-     (let [a (util/clip 1 90 (Math/abs (:magnitude angle angle)))
+     (let [a (util/clip 1 90 (abs (:magnitude angle angle)))
            color-2 (rotate-hue color a)]
        [(rotate-hue color 0)
         (complement color)
@@ -410,7 +414,7 @@
      (shades color 10))
   ([color step]
      (let [c (as-hsl color)]
-       (for [i (range 1 (Math/floor (/ 100.0 step)))]
+       (for [i (range 1 (int (/ 100.0 step)))]
          (assoc c :lightness (* i step))))))
 
 ;; ---------------------------------------------------------------------

--- a/src/garden/repl.clj
+++ b/src/garden/repl.clj
@@ -9,23 +9,24 @@
                          CSSFunction
                          CSSAtRule)
            (garden.color CSSColor)
-           (garden.selectors CSSSelector)))
+           (garden.selectors CSSSelector)
+           (java.io Writer)))
 
 (defmethod print-method CSSUnit [css-unit writer]
-  (.write writer (compiler/render-css css-unit)))
+  (.write ^Writer writer ^String (compiler/render-css css-unit)))
 
 (defmethod print-method CSSFunction [css-function writer]
-  (.write writer (compiler/render-css css-function)))
+  (.write ^Writer writer ^String (compiler/render-css css-function)))
 
 (defmethod print-method CSSColor [color writer]
-  (.write writer (compiler/render-css color)))
+  (.write ^Writer writer ^String (compiler/render-css color)))
 
 (defmethod print-method CSSAtRule [css-at-rule writer]
   (let [f (if (or (util/at-keyframes? css-at-rule)
                   (util/at-media? css-at-rule))
             compiler/compile-css
             compiler/render-css)]
-    (.write writer (f css-at-rule))))
+    (.write ^Writer writer ^String (f css-at-rule))))
 
 (defmethod print-method CSSSelector [css-selector writer]
-  (.write writer (selectors/css-selector css-selector)))
+  (.write ^Writer writer ^String (selectors/css-selector css-selector)))

--- a/src/garden/units.cljc
+++ b/src/garden/units.cljc
@@ -184,13 +184,10 @@
         (convert x unit))
 
       :else
-      (let [;; Does `.getName` even work in CLJS? -- @noprompt
-            ex-message (util/format "Unable to convert from %s to %s"
-                                    (.getName type)
+      (let [ex-message (util/format "Unable to convert %s to %s"
+                                    x
                                     (name unit))
-            ;; TODO: This needs to be populated with more helpful
-            ;; data.
-            ex-data {:given {:type type
+            ex-data {:given {:x x
                              :unit unit}}]
         (throw
          (ex-info ex-message ex-data))))))

--- a/test/garden/color_test.cljc
+++ b/test/garden/color_test.cljc
@@ -221,3 +221,22 @@
 (deftest weighted-mix-test []
   (testing "weighted-mix basics"
     (is (= "#000000" (color/weighted-mix "#000" "#fff" 0)))))
+
+(deftest tetrad-test []
+  (testing "tetrad basics"
+    (let [[{h1 :hue s1 :saturation l1 :lightness}
+           {h2 :hue s2 :saturation l2 :lightness}
+           {h3 :hue s3 :saturation l3 :lightness}
+           {h4 :hue s4 :saturation l4 :lightness}]
+          (color/tetrad (color/from-name "aquamarine"))]
+      (is (= h1 5115/32))  (is (= s1 100N)) (is (= l1 3820/51))
+      (is (= h2 10875/32)) (is (= s2 100N)) (is (= l2 3820/51))
+      (is (= h3 7995/32))  (is (= s3 100N)) (is (= l3 3820/51))
+      (is (= h4 2235/32))  (is (= s4 100N)) (is (= l4 3820/51)))))
+
+(deftest shades-test []
+  (testing "shades basics"
+    (let [aquamarine-shades (color/shades (color/from-name "aquamarine"))]
+      (is (every? (comp #{5115/32} :hue) aquamarine-shades))
+      (is #(= [10 20 30 40 50 60 70 80 90]
+              (map :lightness aquamarine-shades))))))


### PR DESCRIPTION
 - `lein check` is clean now
 - Added basic tests for untested areas I touched

---

`lein check` output on master:
```
$ lein check
Warning: implicit hook found: lein-npm.plugin/hooks 
Hooks are deprecated and will be removed in a future version.
Compiling namespace garden.def
Reflection warning, garden/color.cljc:183:25 - call to static method round on java.lang.Math can't be resolved (argument types: java.lang.Number).
Reflection warning, garden/color.cljc:398:30 - call to static method abs on java.lang.Math can't be resolved (argument types: unknown).
Reflection warning, garden/units.cljc:189:37 - reference to field getName can't be resolved.
Compiling namespace garden.types
Compiling namespace garden.units
Reflection warning, garden/units.cljc:189:37 - reference to field getName can't be resolved.
Compiling namespace garden.selectors
Compiling namespace garden.stylesheet
Compiling namespace garden.core
Compiling namespace garden.util
Compiling namespace garden.arithmetic
Compiling namespace garden.color
Reflection warning, garden/color.cljc:183:25 - call to static method round on java.lang.Math can't be resolved (argument types: java.lang.Number).
Reflection warning, garden/color.cljc:398:30 - call to static method abs on java.lang.Math can't be resolved (argument types: unknown).
Compiling namespace garden.compiler
Compiling namespace garden.repl
Reflection warning, garden/repl.clj:15:3 - call to method write can't be resolved (target class is unknown).
Reflection warning, garden/repl.clj:18:3 - call to method write can't be resolved (target class is unknown).
Reflection warning, garden/repl.clj:21:3 - call to method write can't be resolved (target class is unknown).
Reflection warning, garden/repl.clj:28:5 - call to method write can't be resolved (target class is unknown).
Reflection warning, garden/repl.clj:31:3 - call to method write can't be resolved (target class is unknown).
Compiling namespace garden.compression
Compiling namespace garden.media
Compiling namespace garden.def-test
Compiling namespace garden.arithmetic-test
Compiling namespace garden.compiler-test
WARNING: compile already refers to: #'clojure.core/compile in namespace: garden.compiler-test, being replaced by: #'garden.compiler-test/compile
Compiling namespace garden.selectors-test
Compiling namespace garden.util-test
Compiling namespace garden.tests
Compiling namespace garden.stylesheet-test
Compiling namespace garden.units-test
Compiling namespace garden.color-test
Compiling namespace user
Compiling namespace garden.def
Compiling namespace garden.types
Compiling namespace garden.units
Reflection warning, garden/units.cljc:189:37 - reference to field getName can't be resolved.
Compiling namespace garden.selectors
Compiling namespace garden.stylesheet
Compiling namespace garden.core
Compiling namespace garden.util
Compiling namespace garden.arithmetic
Compiling namespace garden.color
Reflection warning, garden/color.cljc:183:25 - call to static method round on java.lang.Math can't be resolved (argument types: java.lang.Number).
Reflection warning, garden/color.cljc:398:30 - call to static method abs on java.lang.Math can't be resolved (argument types: unknown).
Compiling namespace garden.compiler
Compiling namespace garden.repl
Reflection warning, garden/repl.clj:15:3 - call to method write can't be resolved (target class is unknown).
Reflection warning, garden/repl.clj:18:3 - call to method write can't be resolved (target class is unknown).
Reflection warning, garden/repl.clj:21:3 - call to method write can't be resolved (target class is unknown).
Reflection warning, garden/repl.clj:28:5 - call to method write can't be resolved (target class is unknown).
Reflection warning, garden/repl.clj:31:3 - call to method write can't be resolved (target class is unknown).
Compiling namespace garden.compression
Compiling namespace garden.media
```

---

`lein check` output on this branch:
```
$ lein check
Warning: implicit hook found: lein-npm.plugin/hooks 
Hooks are deprecated and will be removed in a future version.
Compiling namespace garden.def
Compiling namespace garden.types
Compiling namespace garden.units
Compiling namespace garden.selectors
Compiling namespace garden.stylesheet
Compiling namespace garden.core
Compiling namespace garden.util
Compiling namespace garden.arithmetic
Compiling namespace garden.color
Compiling namespace garden.compiler
Compiling namespace garden.repl
Compiling namespace garden.compression
Compiling namespace garden.media
Compiling namespace garden.def-test
Compiling namespace garden.arithmetic-test
Compiling namespace garden.compiler-test
Compiling namespace garden.selectors-test
Compiling namespace garden.util-test
Compiling namespace garden.tests
Compiling namespace garden.stylesheet-test
Compiling namespace garden.units-test
Compiling namespace garden.color-test
Compiling namespace user
Compiling namespace garden.def
Compiling namespace garden.types
Compiling namespace garden.units
Compiling namespace garden.selectors
Compiling namespace garden.stylesheet
Compiling namespace garden.core
Compiling namespace garden.util
Compiling namespace garden.arithmetic
Compiling namespace garden.color
Compiling namespace garden.compiler
Compiling namespace garden.repl
Compiling namespace garden.compression
Compiling namespace garden.media
```