### PR TITLE
Fixing removal of units by YUI for X.0 float values

### DIFF
--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -561,9 +561,13 @@
   [css-unit]
   (let [{:keys [magnitude unit]} css-unit
         magnitude #?(:cljs magnitude)
-        #?(:clj (if (ratio? magnitude)
-                  (float magnitude)
-                  magnitude))]
+        #?(:clj (let [non-ratio (if (ratio? magnitude)
+                                  (float magnitude)
+                                  magnitude)
+                      int-magnitude (int non-ratio)]
+                  (if (and (float? non-ratio) (== non-ratio int-magnitude)) ;; workaround for https://github.com/yui/yuicompressor/issues/108
+                    int-magnitude
+                    non-ratio))
     (str magnitude (name unit))))
 
 (defn- render-function


### PR DESCRIPTION
A work around which detects floats ending with .0 and converts them to int. Without this, when :pretty-print? is set to true, YUI removes the CSS unit making the output invalid. This fixes #119.