### PR TITLE
Add `fr` unit

### DIFF
--- a/src/garden/units.cljc
+++ b/src/garden/units.cljc
@@ -152,7 +152,7 @@
              and unit are captured."
        :private true}
   unit-re
-  #"([+-]?\d+(?:\.?\d+)?)(p[xtc]|in|[cm]m|%|r?em|ex|ch|v(?:[wh]|m(?:in|ax))|deg|g?rad|turn|m?s|k?Hz|dp(?:i|cm|px))")
+  #"([+-]?\d+(?:\.?\d+)?)(p[xtc]|in|[cm]m|%|r?em|ex|ch|v(?:[wh]|m(?:in|ax))|fr|deg|g?rad|turn|m?s|k?Hz|dp(?:i|cm|px))")
 
 (defn read-unit
   "Read a `CSSUnit` object from the string `s`."
@@ -309,6 +309,10 @@
 (defunit vh)
 (defunit vmin)
 (defunit vmax)
+
+;; Grid track length
+
+(defunit fr)
 
 ;; Angles
 

--- a/test/garden/units_test.cljc
+++ b/test/garden/units_test.cljc
@@ -105,6 +105,7 @@
       (units/vh 1) (units/read-unit "1vh")
       (units/vmin 1) (units/read-unit "1vmin")
       (units/vmax 1) (units/read-unit "1vmax")
+      (units/fr 1) (units/read-unit "1fr")
       (units/deg 1) (units/read-unit "1deg")
       (units/grad 1) (units/read-unit "1grad")
       (units/rad 1) (units/read-unit "1rad")


### PR DESCRIPTION
Fixes #183

## All Tests Pass
```
$ lein test-cljc

...

Ran 31 tests containing 321 assertions.
0 failures, 0 errors.

...

Ran 28 tests containing 310 assertions.
0 failures, 0 errors.
```

## Test Task Exception

Running tests with the current project dependencies under Java 11 is broken, throwing the following exception:
```
java.lang.ClassNotFoundException: javax.xml.bind.DatatypeConverter, compiling:(cljs/closure.clj:1:1)
```

I believe that from Java 9 on, `javax.xml.bind` is no longer bundled with Java, and needs to be explicitly declared as a dependency. The specified version of ClojureScript in this project doesn't seem to do so.

**Fix**: Change ClojureScript dep from `1.7.228` to the most recent, `1.11.4`

I'll add this version bump in a separate PR.