### PR TITLE
Add `abs` to refer-clojure exclude in garden.color

### DIFF
--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -1,6 +1,6 @@
 (ns garden.color
   "Utilities for color creation, conversion, and manipulation."
-  (:refer-clojure :exclude [complement])
+  (:refer-clojure :exclude [abs complement])
   #?(:cljs
      (:require-macros
       [garden.color :refer [defcolor-operation]]))


### PR DESCRIPTION
Fixes #194

All tests pass.