### PR TITLE
Add `marker` pseudo class in garden.selectors

### DIFF
--- a/src/garden/selectors.cljc
+++ b/src/garden/selectors.cljc
@@ -816,6 +816,7 @@
     first-of-type
     fullscreen
     focus
+    marker
     hover
     indeterminate
     in-range


### PR DESCRIPTION
Reference to the original issue #197