### PR TITLE
Add support for paged media with @page at-rule

### DIFF
--- a/ideas/selectors.clj
+++ b/ideas/selectors.clj
@@ -53,12 +53,12 @@
    :form i})
 
 (defn separated-list* [op coll]
-  (reduce 
+  (reduce
    (fn [data [index x]]
      (-> data
          (update-in [:children] conj index)
          (assoc index x)))
-   {:op op 
+   {:op op
     :children []}
    (map-indexed vector coll)))
 
@@ -119,7 +119,7 @@
    :else
    (str (float magnitude) (name type))))
 
-;; Primatives
+;; Primitives
 
 (defmethod compile :number
   [{:keys [form]}]

--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -282,8 +282,9 @@
 
 (defmethod expand-at-rule :page
   [{:keys [value]}]
-  (let [{:keys [page-properties rules]} value]
-    (->> {:page-properties page-properties
+  (let [{:keys [named-page page-properties rules]} value]
+    (->> {:named-page named-page
+          :page-properties page-properties
           :rules (map (fn [[ident rules]]
                         [(list (list ident)) (expand rules)])
                       rules)}
@@ -675,8 +676,9 @@
 
 (defmethod render-at-rule :page
   [{:keys [value]}]
-  (let [{:keys [page-properties rules]} value]
+  (let [{:keys [named-page page-properties rules]} value]
     (str "@page "
+         (when named-page (name named-page))
          l-brace
          (render-css page-properties)
          (when (seq rules)

--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -103,7 +103,8 @@
       (util/at-import? x)
       (util/at-media? x)
       (util/at-supports? x)
-      (util/at-keyframes? x)))
+      (util/at-keyframes? x)
+      (util/at-page? x)))
 
 (defn- divide-vec
   "Return a vector of [(filter pred coll) (remove pred coll)]."
@@ -276,6 +277,18 @@
       (CSSAtRule. :feature {:feature-queries feature-queries
                             :rules rules})
       subqueries)))
+
+;; @page expansion
+
+(defmethod expand-at-rule :page
+  [{:keys [value]}]
+  (let [{:keys [page-properties rules]} value]
+    (->> {:page-properties page-properties
+          :rules (map (fn [[ident rules]]
+                        [(list (list ident)) (expand rules)])
+                      rules)}
+         (CSSAtRule. :page)
+         (list))))
 
 ;; ---------------------------------------------------------------------
 ;; Stylesheet expansion
@@ -657,6 +670,21 @@
                (rule-join)
                (indent-str))
            r-brace-1))))
+
+;; @page
+
+(defmethod render-at-rule :page
+  [{:keys [value]}]
+  (let [{:keys [page-properties rules]} value]
+    (str "@page "
+         l-brace
+         (render-css page-properties)
+         (when (seq rules)
+           (str rule-sep
+                (-> (map render-css rules)
+                    (rule-join)
+                    (indent-str))))
+         r-brace)))
 
 ;; ---------------------------------------------------------------------
 ;; CSSRenderer implementation

--- a/src/garden/stylesheet.cljc
+++ b/src/garden/stylesheet.cljc
@@ -48,11 +48,11 @@
 (defn at-import
   "Create a CSS @import rule."
   ([url]
-     (at-rule :import {:url url
-                       :media-queries nil}))
+   (at-rule :import {:url url
+                     :media-queries nil}))
   ([url & media-queries]
-     (at-rule :import {:url url
-                       :media-queries media-queries})))
+   (at-rule :import {:url url
+                     :media-queries media-queries})))
 
 (defn at-media
   "Create a CSS @media rule."
@@ -71,6 +71,12 @@
   [identifier & frames]
   (at-rule :keyframes {:identifier identifier
                        :frames frames}))
+
+(defn at-page
+  "Create a CSS @page rule."
+  [page-properties & rules]
+  (at-rule :page {:page-properties page-properties
+                  :rules rules}))
 
 ;;;; ## Functions
 

--- a/src/garden/stylesheet.cljc
+++ b/src/garden/stylesheet.cljc
@@ -74,8 +74,9 @@
 
 (defn at-page
   "Create a CSS @page rule."
-  [page-properties & rules]
-  (at-rule :page {:page-properties page-properties
+  [named-page page-properties & rules]
+  (at-rule :page {:named-page named-page
+                  :page-properties page-properties
                   :rules rules}))
 
 ;;;; ## Functions

--- a/src/garden/util.cljc
+++ b/src/garden/util.cljc
@@ -116,6 +116,11 @@
   [x]
   (and (at-rule? x) (= (:identifier x) :keyframes)))
 
+(defn at-page?
+  "True if `x` is a CSS `@keyframes` rule."
+  [x]
+  (and (at-rule? x) (= (:identifier x) :page)))
+
 (defn at-import?
   "True if `x` is a CSS `@import` rule."
   [x]
@@ -134,7 +139,7 @@
   [p s]
   (let [p (to-str p)]
     (if (= \- (first p))
-      (prefix p s) 
+      (prefix p s)
       (prefix (str \- p) s))))
 
 ;; ---------------------------------------------------------------------
@@ -155,7 +160,7 @@
 (defn clip
   "Return a number such that n is no less than a and no more than b."
   [a b n]
-  (let [[a b] (if (<= a b) [a b] [b a])] 
+  (let [[a b] (if (<= a b) [a b] [b a])]
     (max a (min b n))))
 
 (defn average

--- a/test/garden/compiler_test.cljc
+++ b/test/garden/compiler_test.cljc
@@ -6,7 +6,7 @@
       :cljs [garden.types :as types :refer [CSSFunction CSSUnit]])
    [garden.color :as color]
    [garden.compiler :refer [compile-css expand render-css]]
-   [garden.stylesheet :refer (at-import at-media at-keyframes at-supports)])
+   [garden.stylesheet :refer (at-import at-media at-keyframes at-supports at-page)])
   #?(:clj
      (:import garden.types.CSSFunction
               garden.types.CSSUnit)))
@@ -196,8 +196,15 @@
            (compile-helper [:.foo
                             {:color "red"}
                             (at-keyframes :id
-                                         ["0%" {:x 0}]
-                                         ["100%" {:x 1}])])))))
+                                          ["0%" {:x 0}]
+                                          ["100%" {:x 1}])]))))
+  (testing "@page"
+    (is (= "@page{size:A4;margin:10px}"
+           (compile-helper (at-page {:size "A4"
+                                     :margin "10px"}))))
+    (is (= "@page{size:A3;@bottom-right-corner{content:'Page ' counter(page)}}"
+           (compile-helper (at-page {:size "A3"}
+                                    ["@bottom-right-corner" {:content "'Page ' counter(page)"}]))))))
 
 (deftest flag-tests
   (testing ":vendors"

--- a/test/garden/compiler_test.cljc
+++ b/test/garden/compiler_test.cljc
@@ -200,10 +200,15 @@
                                           ["100%" {:x 1}])]))))
   (testing "@page"
     (is (= "@page{size:A4;margin:10px}"
-           (compile-helper (at-page {:size "A4"
-                                     :margin "10px"}))))
+           (compile-helper (at-page nil {:size "A4"
+                                         :margin "10px"}))))
     (is (= "@page{size:A3;@bottom-right-corner{content:'Page ' counter(page)}}"
-           (compile-helper (at-page {:size "A3"}
+           (compile-helper (at-page nil
+                                    {:size "A3"}
+                                    ["@bottom-right-corner" {:content "'Page ' counter(page)"}]))))
+    (is (= "@page cover{size:A3;@bottom-right-corner{content:'Page ' counter(page)}}"
+           (compile-helper (at-page :cover
+                                    {:size "A3"}
                                     ["@bottom-right-corner" {:content "'Page ' counter(page)"}]))))))
 
 (deftest flag-tests


### PR DESCRIPTION
Hi,

I contribute with this PR to add `@page` at-rule syntax:
https://developer.mozilla.org/en-US/docs/Web/CSS/@page

Firstly, this adds support for this specific case:
```
@page {
  /* margin box at top right showing page number */
  @top-right {
    content: "Page " counter(pageNumber);
  }
}
```
If interested, I'll also add the support of pseudo-classes.
```
/* Targets all even-numbered pages */
@page :left {
  margin-top: 4in;
}
``` 

Best regards.
Mike