### PR TITLE
Compiler was not able to output to paths where some folder did not exist yet

### DIFF
--- a/src/garden/compiler.cljc
+++ b/src/garden/compiler.cljc
@@ -14,6 +14,8 @@
      (:require-macros
       [garden.compiler :refer [with-media-query-context with-selector-context]]))
   #?(:clj
+     [:require [clojure.java.io :as jio]])
+  #?(:clj
      (:import (garden.types CSSUnit CSSFunction CSSAtRule)
               (garden.color CSSColor))))
 
@@ -114,6 +116,7 @@
    (defn- save-stylesheet
      "Save a stylesheet to disk."
      [path stylesheet]
+     (jio/make-parents path)
      (spit path stylesheet)))
 
 ;; =====================================================================

--- a/src/garden/selectors.cljc
+++ b/src/garden/selectors.cljc
@@ -1015,7 +1015,7 @@
         pseudo-element-re #"^::[a-zA-Z][\w-]*"]
     (some
      (fn [[re k]]
-       (if-let [m (re-find re s)]
+       (when-let [m (re-find re s)]
          [m k]))
      [[id-selector-re :a]
       [class-selector-re :b]

--- a/src/garden/stylesheet.cljc
+++ b/src/garden/stylesheet.cljc
@@ -21,7 +21,7 @@
   Ex.
       (let [text-field (rule \"[type=\"text\"])]
        (text-field {:border [\"1px\" :solid \"black\"]}))
-      ;; => [\"[type=\"text\"] {:boder [\"1px\" :solid \"black\"]}]"
+      ;; => [\"[type=\"text\"] {:border [\"1px\" :solid \"black\"]}]"
   [selector & more]
   (if-not (or (keyword? selector)
               (string? selector)
@@ -60,8 +60,9 @@
   (at-rule :media {:media-queries media-queries
                    :rules rules}))
 
-(defn at-supports [feature-queries & rules]
+(defn at-supports
   "Create a CSS @supports rule."
+  [feature-queries & rules]
   (at-rule :feature {:feature-queries feature-queries
                      :rules rules}))
 


### PR DESCRIPTION
The compiler uses until now the spit function to create the file where the output Is written.

Typically outputs of the compiler are written to a target or public folder that holds autogenerated css, js, html. It is not untypical that a cleaning workflow removes the whole folder that contains autogenerated files, and that would mean that next runs of the compiler would not be able to complete the action as the folder no longer exists.

There is an existing function precisely for this, to be called before spit. I've just added it.
