### PR TITLE
Fix hsla alpha channel in `as-hex`

### DIFF
--- a/src/garden/color.cljc
+++ b/src/garden/color.cljc
@@ -241,7 +241,7 @@
 (defn hsla->hex
   "Convert an HSLA color map to a hexadecimal string."
   [color]
-  (-> color hsla->rgba rgb->hex))
+  (-> color hsla->rgba rgba->hex))
 
 (defn hex->hsl
   "Convert a hexadecimal color to an HSL color."

--- a/test/garden/color_test.cljc
+++ b/test/garden/color_test.cljc
@@ -107,7 +107,13 @@
       (color/as-hex rgba-red) hexa-red
       (color/as-hex rgba-green) hexa-green
       (color/as-hex rgba-blue) hexa-blue
-      (color/as-hex rgba-white) hexa-white)))
+      (color/as-hex rgba-white) hexa-white
+
+      (color/as-hex hsla-black) hexa-black
+      (color/as-hex hsla-red) hexa-red
+      (color/as-hex hsla-green) hexa-green
+      (color/as-hex hsla-blue) hexa-blue
+      (color/as-hex hsla-white) hexa-white)))
 
 (deftest color-math-test
   (testing "color+"


### PR DESCRIPTION
was using a function that ignored alpha in `hsla->hex`, so it was getting dropped